### PR TITLE
Add formula for rtf

### DIFF
--- a/Formula/rtf.rb
+++ b/Formula/rtf.rb
@@ -1,0 +1,25 @@
+require "language/go"
+
+class Rtf < Formula
+  desc "Regression testing framework"
+  homepage "https://github.com/linuxkit/rtf"
+  head "https://github.com/linuxkit/rtf.git"
+
+  depends_on "go" => :build
+
+  def install
+    mkdir_p buildpath/"src/github.com/linuxkit"
+    ln_s buildpath, buildpath/"src/github.com/linuxkit/rtf"
+
+    ENV["GOPATH"] = "#{buildpath}/Godeps/_workspace:#{buildpath}"
+
+    system "make build"
+
+    bin.install "_build/rtf"
+  end
+
+  test do
+    output = shell_output(bin/"rtf version")
+    assert_match "rtf version", output
+  end
+end


### PR DESCRIPTION
This commit adds a formula to install linuxkit/rtf
rtf is the test framework used for running the linuxkit test suite

Fixes: #1

Signed-off-by: Dave Tucker <dt@docker.com>