### PR TITLE
Add some CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+os: osx
+before_install:
+  - brew update
+  - brew --env
+  - brew config
+install:
+  - mkdir -p $(brew --repo)/Library/Taps/linuxkit
+  - ln -s $TRAVIS_BUILD_DIR $(brew --repo)/Library/Taps/linuxkit/homebrew-linuxkit
+script:
+  - ./test.sh

--- a/Formula/linuxkit.rb
+++ b/Formula/linuxkit.rb
@@ -1,7 +1,5 @@
-require "language/go"
-
 class Linuxkit < Formula
-  desc "Lightweight Linux districution tool"
+  desc "Lightweight Linux distribution tool"
   homepage "https://github.com/linuxkit/linuxkit"
   head "https://github.com/linuxkit/linuxkit.git"
 
@@ -19,7 +17,7 @@ class Linuxkit < Formula
   end
 
   test do
-    output = shell_output(bin/"moby version")
-    assert_match "moby version", output
+    output = shell_output(bin/"linuxkit version")
+    assert_match "linuxkit version", output
   end
 end

--- a/Formula/moby.rb
+++ b/Formula/moby.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class Moby < Formula
   desc "Container assembly tool"
   homepage "https://github.com/moby/tool"

--- a/Formula/rtf.rb
+++ b/Formula/rtf.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class Rtf < Formula
   desc "Regression testing framework"
   homepage "https://github.com/linuxkit/rtf"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+
+PKGS="$(find Formula -iname "*.rb" -exec sh -c 'FORMULA={}; basename ${FORMULA%.*}' \;)"
+
+for pkg in ${PKGS}; do
+	brew install --HEAD $pkg --verbose
+	# Skip audit until we have a stable download
+	# brew audit $pkg --strict
+	brew test $pkg
+done


### PR DESCRIPTION
This adds a .travis.yml file, ready for plumbing in to TravisCI.
Fixes the linuxkit test to use `linuxkit -version`
Removes `requires: language/go` on recommendation of brew audit --strict
Note: brew audit is disabled for now as it complains about this tap not
being called `linuxkit-head-only` and containg only head-only versions

Signed-off-by: Dave Tucker <dt@docker.com>