### PR TITLE
Drop require go from manifest-tool.rb

### DIFF
--- a/Formula/manifest-tool.rb
+++ b/Formula/manifest-tool.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class ManifestTool < Formula
   desc "Multi arch registry tool"
   homepage "https://github.com/estesp/manifest-tool"


### PR DESCRIPTION
It is unsupported nowadays.
Moreover, this formula may be outright dropped, given that there is one for manifest-tool included now in homebrew-core